### PR TITLE
Add tests for API Version 2

### DIFF
--- a/pyartifactory/artifactory_object.py
+++ b/pyartifactory/artifactory_object.py
@@ -16,6 +16,7 @@ class ArtifactoryObject:
             self._artifactory.auth[0],
             self._artifactory.auth[1].get_secret_value(),
         )
+        self._api_version = self._artifactory.api_version
         self._verify = self._artifactory.verify
         self._cert = self._artifactory.cert
         self.session = requests.Session()

--- a/pyartifactory/objects.py
+++ b/pyartifactory/objects.py
@@ -172,12 +172,12 @@ class ArtifactoryUser(ArtifactoryObject):
 class ArtifactoryPermission(ArtifactoryObject):
     """Models an artifactory permission."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        if self._artifactory.api_version == 1:
+    def __init__(self, artifactory: AuthModel) -> None:
+        super().__init__(artifactory)
+        if self._api_version == 2:
+            self._uri = "v2/security/permissions"
+        if self._api_version == 1:
             self._uri = "security/permissions"
-        if self._artifactory.api_version == 2:
-            self.uri = "v2/security/permissions"
 
     def create(
         self, permission: Union[Permission, PermissionV2]

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -7,11 +7,13 @@ from pyartifactory.exception import (
     PermissionAlreadyExistsException,
 )
 from pyartifactory.models.auth import AuthModel
-from pyartifactory.models.permission import Permission, SimplePermission
+from pyartifactory.models.permission import Permission, SimplePermission, PermissionV2
+
 
 URL = "http://localhost:8080/artifactory"
 AUTH = ("user", "password_or_apiKey")
-
+API_URI = "api/security/permissions"
+API_URI_V2 = "api/v2/security/permissions"
 SIMPLE_PERMISSION = SimplePermission(name="test_permission", uri="someuri")
 PERMISSION = Permission(
     **{
@@ -23,127 +25,172 @@ PERMISSION = Permission(
         },
     }
 )
+PERMISSIONV2 = PermissionV2(
+    **{
+        "name": "test_permission",
+        "repo": {
+            "repositories": ["test_repository"],
+            "actions": {
+                "users": {"test_user": ["read", "annotate", "write", "delete",]},
+                "groups": {"developers": ["read", "annotate", "write", "delete",],},
+            },
+        },
+        "includePatterns": ["**"],
+        "excludePatterns": [],
+    }
+)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_create_permission_fail_if_group_already_exists(mocker):
+def test_create_permission_fail_if_group_already_exists(
+    mocker, api_version, permission, api_uri
+):
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
     with pytest.raises(PermissionAlreadyExistsException):
-        artifactory_permission.create(PERMISSION)
-    artifactory_permission.get.assert_called_once_with(PERMISSION.name)
+        artifactory_permission.create(permission)
+    artifactory_permission.get.assert_called_once_with(permission.name)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_create_permission_success(mocker):
-    responses.add(
-        responses.GET, f"{URL}/api/security/permissions/{PERMISSION.name}", status=404
-    )
+def test_create_permission_success(mocker, api_version, permission, api_uri):
+    responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
     responses.add(
         responses.PUT,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=201,
     )
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
-    permission = artifactory_permission.create(PERMISSION)
-    artifactory_permission.get.assert_called_with(PERMISSION.name)
-    assert permission == PERMISSION.dict()
+    permission = artifactory_permission.create(permission)
+    artifactory_permission.get.assert_called_with(permission.name)
+    assert permission == permission.dict()
 
     assert artifactory_permission.get.call_count == 2
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_get_permission_error_not_found():
-    responses.add(
-        responses.GET, f"{URL}/api/security/permissions/{PERMISSION.name}", status=404
-    )
+def test_get_permission_error_not_found(mocker, api_version, permission, api_uri):
+    responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     with pytest.raises(PermissionNotFoundException):
-        artifactory_permission.get(PERMISSION.name)
+        artifactory_permission.get(permission.name)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_get_permission_success(mocker):
+def test_get_permission_success(mocker, api_version, permission, api_uri):
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
-    permission = artifactory_permission.get(PERMISSION.name)
-    artifactory_permission.get.assert_called_with(PERMISSION.name)
+    permission = artifactory_permission.get(permission.name)
+    artifactory_permission.get.assert_called_with(permission.name)
 
-    assert permission == PERMISSION.dict()
+    assert permission == permission.dict()
 
 
+@pytest.mark.parametrize("api_version,api_uri", [(1, API_URI), (2, API_URI_V2)])
 @responses.activate
-def test_list_group_success(mocker):
+def test_list_group_success(mocker, api_version, api_uri):
     responses.add(
-        responses.GET,
-        f"{URL}/api/security/permissions",
-        json=[SIMPLE_PERMISSION.dict()],
-        status=200,
+        responses.GET, f"{URL}/{api_uri}", json=[SIMPLE_PERMISSION.dict()], status=200,
     )
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "list")
     permission_list = artifactory_permission.list()
     artifactory_permission.list.assert_called_once()
-
     assert permission_list == [SIMPLE_PERMISSION.dict()]
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_delete_permission_fail_if_group_not_found(mocker):
-    responses.add(
-        responses.GET, f"{URL}/api/security/permissions/{PERMISSION.name}", status=404
-    )
+def test_delete_permission_fail_if_group_not_found(
+    mocker, api_version, permission, api_uri
+):
+    responses.add(responses.GET, f"{URL}/{api_uri}/{permission.name}", status=404)
 
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
 
     with pytest.raises(PermissionNotFoundException):
-        artifactory_permission.delete(PERMISSION.name)
+        artifactory_permission.delete(permission.name)
 
-    artifactory_permission.get.assert_called_once_with(PERMISSION.name)
+    artifactory_permission.get.assert_called_once_with(permission.name)
 
 
+@pytest.mark.parametrize(
+    "api_version,permission,api_uri",
+    [(1, PERMISSION, API_URI), (2, PERMISSIONV2, API_URI_V2)],
+)
 @responses.activate
-def test_delete_group_success(mocker):
+def test_delete_group_success(mocker, api_version, permission, api_uri):
     responses.add(
         responses.GET,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        json=PERMISSION.dict(),
+        f"{URL}/{api_uri}/{permission.name}",
+        json=permission.dict(),
         status=200,
     )
 
     responses.add(
-        responses.DELETE,
-        f"{URL}/api/security/permissions/{PERMISSION.name}",
-        status=204,
+        responses.DELETE, f"{URL}/{api_uri}/{permission.name}", status=204,
     )
-    artifactory_permission = ArtifactoryPermission(AuthModel(url=URL, auth=AUTH))
+    artifactory_permission = ArtifactoryPermission(
+        AuthModel(url=URL, auth=AUTH, api_version=api_version)
+    )
     mocker.spy(artifactory_permission, "get")
-    artifactory_permission.delete(PERMISSION.name)
+    artifactory_permission.delete(permission.name)
 
-    artifactory_permission.get.assert_called_once_with(PERMISSION.name)
+    artifactory_permission.get.assert_called_once_with(permission.name)


### PR DESCRIPTION
Using pytest.mark.parametrize, the test can be run
twice for each version of the API to ensure
backwards compatibility.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has it been tested ?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [ ] My PR is ready for prime time! Otherwise use the ["Draft PR" feature](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
- [ ] All commits have a correct title
- [ ] Readme has been updated
- [ ] Quality tests are green (see Codacy)
- [ ] Automated tests are green (see pipeline)
